### PR TITLE
Fix property exception handling.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.simple</groupId>
     <artifactId>simplespec_2.10.1</artifactId>
-    <version>0.8.2</version>
+    <version>0.8.3</version>
     <packaging>jar</packaging>
 
     <name>simplespec for Scala ${scala.version}</name>

--- a/src/main/scala/com/simple/simplespec/matchers/PropertyMatchers.scala
+++ b/src/main/scala/com/simple/simplespec/matchers/PropertyMatchers.scala
@@ -14,8 +14,11 @@ trait PropErrorMatcher {
 
   def throwIfError(r: Test.Result) {
     r.status match {
-      case Test.PropException(_, e, _) => throw new AssertionError(pretty(r), e)
-      case Test.GenException(e) => throw new AssertionError(pretty(r), e)
+      case Test.PropException(_, e, _) =>
+        throw new RuntimeException(pretty(r), e)
+
+      case Test.GenException(e) =>
+        throw new RuntimeException(pretty(r), e)
       case _ =>
     }
   }

--- a/src/test/scala/com/simple/simplespec/specs/MatchersSpec.scala
+++ b/src/test/scala/com/simple/simplespec/specs/MatchersSpec.scala
@@ -309,13 +309,13 @@ class PropertyMatchersSpec extends Spec {
     @Test def `Exceptions generating data are re-thrown` {
       evaluating {
         throwIfError(genEx)
-      }.must(throwAn[AssertionError])
+      }.must(throwA[RuntimeException])
     }
 
     @Test def `Exceptions evaluating properties data are re-thrown` {
       evaluating {
         throwIfError(propEx)
-      }.must(throwAn[AssertionError])
+      }.must(throwA[RuntimeException])
     }
   }
 


### PR DESCRIPTION
This patch updates `PropErrorMatcher.throwIfError` to throw a `RuntimeException` rather than an `AssertionError`. The `AssertionError` causes JUnit to treat the exception as a failed test rather than a test error. This also causes the stack of the `AssertionError` to be printed rather than the stack of the original exception.
