### PR TITLE
Fix broken notNull

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.simple</groupId>
     <artifactId>simplespec_2.10.1</artifactId>
-    <version>0.8.3</version>
+    <version>0.8.4</version>
     <packaging>jar</packaging>
 
     <name>simplespec for Scala ${scala.version}</name>

--- a/src/main/scala/com/simple/simplespec/Matchers.scala
+++ b/src/main/scala/com/simple/simplespec/Matchers.scala
@@ -131,7 +131,7 @@ trait Matchers extends Matchables with Mocks with PropertyMatchers {
   // FWIW, this is the only expressed negative in the matchers for a reason.
   // I'd rather express nullity as a double-negative in tests to express how
   // ungainly it is to deal with in an API.
-  def notNull[A] = CoreMatchers.notNullValue()
+  def notNull[A] = CoreMatchers.notNullValue().asInstanceOf[Matcher[A]]
 
   /**
    * Is the value equal to the given value, plus or minus the given delta?

--- a/src/test/scala/com/simple/simplespec/specs/MatchersSpec.scala
+++ b/src/test/scala/com/simple/simplespec/specs/MatchersSpec.scala
@@ -107,6 +107,14 @@ class EqualityAssertionSpec extends Matchables with Matchers {
       1.must(equal(2))
     }.must(throwAn[AssertionError])
   }
+
+  @Test
+  def notNullMustWork() {
+    evaluating {
+      val x: String = null
+      x.must(be(notNull))
+    }.must(throwAn[AssertionError])
+  }
 }
 
 class ClassSpec extends Matchables with Matchers {


### PR DESCRIPTION
Something in junit 4.11 or something in the conversion over to it broke `notNull` -- this fixes it back and adds a test.
