### PR TITLE
README typos and links

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,4 +413,4 @@ Copyright (c) 2010-2012 Coda Hale
 
 Copyright (c) 2012-2014 Simple Finance Technology
 
-Published under The MIT License, see LICENSE
+Published under The MIT License, see [`LICENSE.md`](LICENSE.md)


### PR DESCRIPTION
Fixes parentheses in the list of matchers. Points to Google Code for Mockito, since mockito.org seemse to have expired. Adds a link to LICENSE.md.
